### PR TITLE
Let the object message output of the node be clonable

### DIFF
--- a/google.js
+++ b/google.js
@@ -139,7 +139,7 @@ module.exports = function(RED) {
                 });
 
                 msg.payload = res;
-
+                delete msg.payload.request
                 node.send(msg);
             });
 

--- a/google.js
+++ b/google.js
@@ -137,9 +137,7 @@ module.exports = function(RED) {
                     shape: 'dot',
                     text: 'success'
                 });
-
-                msg.payload = res;
-                delete msg.payload.request
+                msg.payload = res.data;
                 node.send(msg);
             });
 


### PR DESCRIPTION
Since Node-Red v1.0, Node-Red uses a lot of cloning messages to ensure there is no unintended modification of message objects that get reused. As the clone function cannot clone "res", I propose to delete the request part of the message since it cannot be cloned and creates the following error: "node:1408) UnhandledPromiseRejectionWarning: TypeError: Cannot set property bytesRead of #<Socket> which has only a getter"